### PR TITLE
FIX correct proportion for core

### DIFF
--- a/General_Scripts/07_taxonomy_core_analysis/utils/core.py
+++ b/General_Scripts/07_taxonomy_core_analysis/utils/core.py
@@ -8,7 +8,7 @@ def classificationprop(x):
     Classify the prevalence percent
     into different categories
     '''
-    if x >= 90: return 'core'
+    if x >= 95: return 'core'
     if x >= 50: return 'shell'
     if x < 50: return 'accessory'
 


### PR DESCRIPTION
Outdated value for the prevalence threshold for assigning core AMPs or families.
Fixing 90% threshold to 95% threshold.